### PR TITLE
fix android:lineHeight

### DIFF
--- a/app/src/main/res/layout/gemtext_quote.xml
+++ b/app/src/main/res/layout/gemtext_quote.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.appcompat.widget.AppCompatTextView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.appcompat.widget.AppCompatTextView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/gemtext_quote_textview"
     android:textSize="@dimen/default_text_size"
     android:textColor="@color/stroke"
@@ -15,4 +15,4 @@
     android:textIsSelectable="true"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:lineHeight="@dimen/default_line_height"/>
+    app:lineHeight="@dimen/default_line_height" />

--- a/app/src/main/res/layout/gemtext_text.xml
+++ b/app/src/main/res/layout/gemtext_text.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.appcompat.widget.AppCompatTextView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.appcompat.widget.AppCompatTextView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/gemtext_text_textview"
     android:textSize="@dimen/default_text_size"
     android:layout_marginLeft="@dimen/screen_margin"
@@ -9,4 +9,4 @@
     android:textIsSelectable="true"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:lineHeight="@dimen/default_line_height"/>
+    app:lineHeight="@dimen/default_line_height" />


### PR DESCRIPTION
Hello,

I found you have used ``android:lineHeight`` in your app. It was introduced at API Level 28. It will not take any effects for low API levels.

I can reproduce the differences here.

API Level 29
![2631659797271_ pic](https://user-images.githubusercontent.com/109571086/183254350-abfe99d9-cc7c-4dea-87ee-15acb7d52cd2.jpg)


API Level 27
![2641659797758_ pic](https://user-images.githubusercontent.com/109571086/183254360-1e8e12a8-a115-4fa7-bdd0-dfb55ebbbdec.jpg)


You can change it to ``app:lineHeight`` as you did in https://github.com/Corewala/Buran/blob/2e4b70cec1c4c0e58032abde26e4b1efc519e965/app/src/main/res/layout/gemtext_code_block.xml#L37

The issues have gone on my side by this pull request.

Hope the information is useful for you