### PR TITLE
Fix incorrect Uri resolving when ".." is used instead of "../"

### DIFF
--- a/app/src/main/java/corewala/buran/OppenURI.kt
+++ b/app/src/main/java/corewala/buran/OppenURI.kt
@@ -3,6 +3,7 @@ package corewala.buran
 import corewala.toURI
 
 const val GEMSCHEME = "gemini://"
+const val PART_TRAVERSE = ".."
 const val TRAVERSE = "../"
 const val SOLIDUS = "/"
 const val DIREND = "/"
@@ -41,10 +42,14 @@ class OppenURI constructor(private var ouri: String) {
         when {
             reference.startsWith(GEMSCHEME) -> set(reference)
             reference.startsWith(SOLIDUS) -> resolvedUri = "$scheme://$host$reference"
-            reference.startsWith(TRAVERSE) -> {
-                if(!ouri.endsWith(DIREND)) resolvedUri = ouri.removeFile()
-                val traversalCount = reference.split(TRAVERSE).size - 1
-                resolvedUri = traverse(traversalCount) + reference.replace(TRAVERSE, "")
+            reference.startsWith(PART_TRAVERSE) -> {
+		val fixedReference = if (reference == PART_TRAVERSE) "$reference/" else reference
+                if (!ouri.endsWith(DIREND)) {
+                    resolvedUri = ouri.removeFile()
+                } else {
+                    val traversalCount = fixedReference.split(TRAVERSE).size - 1
+                    resolvedUri = traverse(traversalCount) + fixedReference.replace(TRAVERSE, "")
+                }
             }
             reference.startsWith(QUERY) -> {
                 resolvedUri = if(reference.contains(QUERY)){


### PR DESCRIPTION
### Description

When ".." is used instead of "../" as link to upper directory, it is incorrectly resolved to "[...]/directory/**..**" to which some Gemini servers react with message "Your directory traversal technique has been defeated" and permanent failure code

### Example

Happens on sites like gemini://gemini.ctrl-c.club/~stack/gemlog/index.gmi 
(the home link at the bottom or in any of the articles)